### PR TITLE
feat(searching): add channel/user search flags

### DIFF
--- a/src/lib/twitch/logs.ts
+++ b/src/lib/twitch/logs.ts
@@ -44,13 +44,13 @@ export const messageSearch = (searchValue: string, chatLogs: Message[], scrollFr
 			return [];
 		}
 	} else if (searchValue.startsWith(searchPrefixes.channel)) {
-		const channel = searchValue.slice(searchPrefixes.channel.length).toLowerCase();
+		const channels = searchValue.slice(searchPrefixes.channel.length).toLowerCase().split(",");
 
-		chatLogs = chatLogs.filter((msg) => msg.channel?.toLowerCase() === channel);
+		chatLogs = chatLogs.filter((msg) => channels.includes(msg.channel?.toLowerCase() ?? ""));
 	} else if (searchValue.startsWith(searchPrefixes.user)) {
-		const user = searchValue.slice(searchPrefixes.user.length).toLowerCase();
+		const users = searchValue.slice(searchPrefixes.user.length).toLowerCase().split(",");
 
-		chatLogs = chatLogs.filter((msg) => msg.displayName.toLowerCase() === user);
+		chatLogs = chatLogs.filter((msg) => users.includes(msg.displayName.toLowerCase()));
 	} else if (searchValue) {
 		const searchOptions = scrollFromBottom === null ? { keys: ["channel", "displayName", "text"], threshold: 0.5 } : { keys: ["text"], threshold: 0.5, limit: 5000 };
 

--- a/src/lib/twitch/logs.ts
+++ b/src/lib/twitch/logs.ts
@@ -30,9 +30,8 @@ export type EmoteProps = {
 
 const searchPrefixes = {
 	regex: "regex:",
-	channel: "channel:",
-	username: "username:",
-	user: "user:",
+	channel: "in:",
+	user: "from:",
 };
 
 export const messageSearch = (searchValue: string, chatLogs: Message[], scrollFromBottom: boolean | null): Message[] => {
@@ -48,8 +47,8 @@ export const messageSearch = (searchValue: string, chatLogs: Message[], scrollFr
 		const channel = searchValue.slice(searchPrefixes.channel.length).toLowerCase();
 
 		chatLogs = chatLogs.filter((msg) => msg.channel?.toLowerCase() === channel);
-	} else if (searchValue.startsWith(searchPrefixes.username) || searchValue.startsWith(searchPrefixes.user)) {
-		const user = searchValue.startsWith(searchPrefixes.username) ? searchValue.slice(searchPrefixes.username.length).toLowerCase() : searchValue.slice(searchPrefixes.user.length).toLowerCase();
+	} else if (searchValue.startsWith(searchPrefixes.user)) {
+		const user = searchValue.slice(searchPrefixes.user.length).toLowerCase();
 
 		chatLogs = chatLogs.filter((msg) => msg.displayName.toLowerCase() === user);
 	} else if (searchValue) {

--- a/src/lib/twitch/logs.ts
+++ b/src/lib/twitch/logs.ts
@@ -30,6 +30,9 @@ export type EmoteProps = {
 
 const searchPrefixes = {
 	regex: "regex:",
+	channel: "channel:",
+	username: "username:",
+	user: "user:",
 };
 
 export const messageSearch = (searchValue: string, chatLogs: Message[], scrollFromBottom: boolean | null): Message[] => {
@@ -41,6 +44,16 @@ export const messageSearch = (searchValue: string, chatLogs: Message[], scrollFr
 		} catch {
 			return [];
 		}
+	} else if (searchValue.startsWith(searchPrefixes.channel)) {
+		const channel = searchValue.slice(searchPrefixes.channel.length).toLowerCase();
+
+		chatLogs = chatLogs.filter((msg) => msg.channel?.toLowerCase() === channel);
+	} else if (searchValue.startsWith(searchPrefixes.username) || searchValue.startsWith(searchPrefixes.user)) {
+		const user = searchValue.startsWith(searchPrefixes.username)
+			? searchValue.slice(searchPrefixes.username.length).toLowerCase()
+			: searchValue.slice(searchPrefixes.user.length).toLowerCase();
+
+		chatLogs = chatLogs.filter((msg) => msg.displayName.toLowerCase() === user);
 	} else if (searchValue) {
 		const searchOptions = scrollFromBottom === null ? { keys: ["channel", "displayName", "text"], threshold: 0.5 } : { keys: ["text"], threshold: 0.5, limit: 5000 };
 

--- a/src/lib/twitch/logs.ts
+++ b/src/lib/twitch/logs.ts
@@ -49,9 +49,7 @@ export const messageSearch = (searchValue: string, chatLogs: Message[], scrollFr
 
 		chatLogs = chatLogs.filter((msg) => msg.channel?.toLowerCase() === channel);
 	} else if (searchValue.startsWith(searchPrefixes.username) || searchValue.startsWith(searchPrefixes.user)) {
-		const user = searchValue.startsWith(searchPrefixes.username)
-			? searchValue.slice(searchPrefixes.username.length).toLowerCase()
-			: searchValue.slice(searchPrefixes.user.length).toLowerCase();
+		const user = searchValue.startsWith(searchPrefixes.username) ? searchValue.slice(searchPrefixes.username.length).toLowerCase() : searchValue.slice(searchPrefixes.user.length).toLowerCase();
 
 		chatLogs = chatLogs.filter((msg) => msg.displayName.toLowerCase() === user);
 	} else if (searchValue) {
@@ -65,4 +63,3 @@ export const messageSearch = (searchValue: string, chatLogs: Message[], scrollFr
 
 	return scrollFromBottom === false ? [...chatLogs].reverse() : chatLogs;
 };
-


### PR DESCRIPTION
@0Supa I think this is the last feature I was wanting to add, but let me know if this is too much. From a UX perspective, once you add enough of these search flags, you might as well make separate search boxes for those? Idk, I'll leave it up to you if you even want to merge this one in. Regex was the main thing I wanted added.

Another thing I was thinking is if you did want to, you could expand on the searching even more allowing regex on the other flags, allow multiple flags at once (again, maybe better for UX to just have a separate box for that and at this point is it even worth it)